### PR TITLE
FEATURE: Added debugger for caching behaviour inspection

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
@@ -83,6 +83,12 @@ class ContentCache
     protected $securityContext;
 
     /**
+     * @var ContentCacheDebugger
+     * @Flow\Inject
+     */
+    protected $debugger;
+
+    /**
      * Takes the given content and adds markers for later use as a cached content segment.
      *
      * This function will add a start and an end token to the beginning and end of the content and generate a cache
@@ -237,11 +243,14 @@ class ContentCache
     public function replaceCachePlaceholders(&$content, $addCacheSegmentMarkersToPlaceholders)
     {
         $cache = $this->cache;
+        $debugger = $this->debugger;
         $foundMissingIdentifier = false;
-        $content = preg_replace_callback(self::CACHE_PLACEHOLDER_REGEX, function ($match) use ($cache, &$foundMissingIdentifier, $addCacheSegmentMarkersToPlaceholders) {
+        $content = preg_replace_callback(self::CACHE_PLACEHOLDER_REGEX, function ($match) use ($cache, &$foundMissingIdentifier, $addCacheSegmentMarkersToPlaceholders, $debugger) {
             $identifier = $match['identifier'];
             $entry = $cache->get($identifier);
             if ($entry !== false) {
+                // if debug enabled this method wraps the entry with identifier information
+                $entry = $debugger->wrapCacheEntry($identifier, $entry);
                 if ($addCacheSegmentMarkersToPlaceholders) {
                     return ContentCache::CACHE_SEGMENT_START_TOKEN . $identifier . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . '*' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . $entry . ContentCache::CACHE_SEGMENT_END_TOKEN;
                 } else {

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCacheDebugger.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCacheDebugger.php
@@ -1,0 +1,54 @@
+<?php
+namespace TYPO3\TypoScript\Core\Cache;
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ *
+ * @Flow\Scope("singleton")
+ */
+class ContentCacheDebugger {
+
+	const DEBUG_GET_PARAMETER = 'debug';
+
+	/**
+	 * @Flow\InjectConfiguration(path="contentCacheDebugger")
+	 * @var array
+	 */
+	protected $settings;
+
+
+	/**
+	 * Overrides the debug settings
+	 *
+	 * @param array $settings
+	 * @return void
+	 */
+	public function setSettings($settings) {
+
+		$settings['enabled'] = $settings['enabled'] && isset($_GET[self::DEBUG_GET_PARAMETER]);
+		$this->settings = $settings;
+	}
+
+
+	/**
+	 * If debug enabled, this method, wraps the a given $entry with $identifier information as comments.
+	 *
+	 * @param $identifier
+	 * @param $entry
+	 *
+	 * @return string
+	 */
+	public function wrapCacheEntry($identifier, $entry) {
+
+		if(!$this->settings['enabled']) return $entry;
+
+		//workaround: remove 'HTTP/1.1 200 OK' in first cache segment
+		return sprintf('
+		<!-- START: %s -->
+		%s
+		<!-- END: %s -->
+		', $identifier, str_replace('HTTP/1.1 200 OK', '', $entry), $identifier);
+	}
+
+}

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCacheDebugger.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCacheDebugger.php
@@ -41,14 +41,14 @@ class ContentCacheDebugger {
 	 */
 	public function wrapCacheEntry($identifier, $entry) {
 
-		if(!$this->settings['enabled']) return $entry;
+		//abort, if debugging disabled OR 'HTTP/...' in cache segment
+		if (!$this->settings['enabled'] || substr($entry, 0, 5) === 'HTTP/') return $entry;
 
-		//workaround: remove 'HTTP/1.1 200 OK' in first cache segment
 		return sprintf('
-		<!-- START: %s -->
-		%s
-		<!-- END: %s -->
-		', $identifier, str_replace('HTTP/1.1 200 OK', '', $entry), $identifier);
+		<!-- START: %1$s -->
+		%2$s
+		<!-- END: %1$s -->
+		', $identifier, $entry);
 	}
 
 }

--- a/TYPO3.TypoScript/Configuration/Settings.yaml
+++ b/TYPO3.TypoScript/Configuration/Settings.yaml
@@ -17,6 +17,8 @@ TYPO3:
       # meta-property in TypoScript, and it is especially useful for e.g. the "TYPO3.TypoScript:ResourceUri"
       # TypoScript Object, which should just return NULL silently if an exception occurs.
       innerExceptionHandler: 'TYPO3\TypoScript\Core\ExceptionHandlers\BubblingHandler'
+    contentCacheDebugger:
+      enabled: FALSE
     debugMode: FALSE
     enableContentCache: TRUE
 


### PR DESCRIPTION
https://cron-eu.atlassian.net/browse/DAVDAZ-727

The debugger wraps cache entries with information about the cache identifier in the HTML source.

The debug can be enabled in the settings with:

```
...
TYPO3:
  TypoScript:
    contentCacheDebugger:
      enabled: TRUE
...
```

Debug information is printed only for URLs with **debug** GET parameter, like:
`http://dev.daz-neos.boot2docker:8080/?debug`
