### PR TITLE
BUGFIX: Build correct paths to nodes with hidden parents

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -117,6 +117,10 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             return false;
         }
 
+        if ($node->getWorkspace()->getName() === 'live' && $node->isHidden() === true) {
+            return false;
+        }
+
         $this->value = $node->getContextPath();
 
         return true;
@@ -495,7 +499,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     {
         $contextProperties = array(
             'workspaceName' => $workspaceName,
-            'invisibleContentShown' => ($workspaceName !== 'live'),
+            'invisibleContentShown' => true,
             'inaccessibleContentShown' => ($workspaceName !== 'live'),
             'dimensions' => $dimensionsAndDimensionValues
         );

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -404,15 +404,24 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             return '';
         }
 
+        // To allow building of paths to non-hidden nodes beneath hidden nodes, we assume
+        // the input node is allowed to be seen and we must generate the full path here.
+        // To disallow showing a node actually hidden itself has to be ensured in matching
+        // a request path, not in building one.
+        $contextProperties = $node->getContext()->getProperties();
+        $contextAllowingHiddenNodes = $this->contextFactory->create(array_merge($contextProperties, ['invisibleContentShown' => true]));
+        $siteNodeFromAdjustedContext = $contextAllowingHiddenNodes->getNodeByIdentifier($siteNode->getIdentifier());
+        $currentNode = $contextAllowingHiddenNodes->getNodeByIdentifier($node->getIdentifier());
+
         $requestPathSegments = array();
-        while ($siteNode !== $node && $node instanceof NodeInterface) {
-            if (!$node->hasProperty('uriPathSegment')) {
+        while ($siteNodeFromAdjustedContext !== $currentNode && $currentNode instanceof NodeInterface) {
+            if (!$currentNode->hasProperty('uriPathSegment')) {
                 throw new Exception\MissingNodePropertyException(sprintf('Missing "uriPathSegment" property for node "%s". Nodes can be migrated with the "flow node:repair" command.', $node->getPath()), 1415020326);
             }
 
-            $pathSegment = $node->getProperty('uriPathSegment');
+            $pathSegment = $currentNode->getProperty('uriPathSegment');
             $requestPathSegments[] = $pathSegment;
-            $node = $node->getParent();
+            $currentNode = $currentNode->getParent();
         }
 
         return implode('/', array_reverse($requestPathSegments));


### PR DESCRIPTION
If a node is visible but lies beneath a hidden parent, the URI path
generated for that node had "holes" and did not work. This adjusts the
route part handler to return the complete URI including the URI path
segments of hidden nodes in the chain up to the site node.

To disallow showing a node actually hidden itself has to be ensured
in matching a request path, not in building one.